### PR TITLE
Add ToS & Privacy modal with dark overlay and checkbox validation

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -25,8 +25,10 @@
 				<div class="dropdown-content">
 					<div class="loginContainer">
 						<form id="loginForm">
-							<input id="username-field" class="login-stuff" type="text" placeholder="Username" name="username" maxlength="16" autocomplete="off" required />
-							<input id="password-field" class="login-stuff" type="password" placeholder="Password" name="password" maxlength="16" autocomplete="off" required />
+							<input id="username-field" class="login-stuff" type="text" placeholder="Username"
+								name="username" maxlength="16" autocomplete="off" required />
+							<input id="password-field" class="login-stuff" type="password" placeholder="Password"
+								name="password" maxlength="16" autocomplete="off" required />
 							<button id="login-button" class="login-stuff" type="button">Login</button>
 						</form>
 					</div>
@@ -37,9 +39,14 @@
 				<div class="dropdown-content">
 					<div class="loginContainer">
 						<form id="registerForm">
-							<input id="register-username-field" class="register-stuff" type="text" placeholder="Username" name="registerUsername" maxlength="16" autocomplete="off" required />
-							<input id="register-password-field" class="register-stuff" type="password" placeholder="Password" name="registerPassword" maxlength="16" autocomplete="off" required />
-							<input id="register-email-field" class="register-stuff" type="email" placeholder="Email" name="registerEmail" maxlength="32" autocomplete="off" required />
+							<input id="register-username-field" class="register-stuff" type="text"
+								placeholder="Username" name="registerUsername" maxlength="16" autocomplete="off"
+								required />
+							<input id="register-password-field" class="register-stuff" type="password"
+								placeholder="Password" name="registerPassword" maxlength="16" autocomplete="off"
+								required />
+							<input id="register-email-field" class="register-stuff" type="email" placeholder="Email"
+								name="registerEmail" maxlength="32" autocomplete="off" required />
 							<button id="register-button" class="register-stuff" type="button">Register</button>
 						</form>
 					</div>
@@ -50,6 +57,22 @@
 </nav>
 
 <body>
+	<!-- Terms of Service & Privacy Policy Modal -->
+	<div id="tos-modal" class="modal-overlay">
+		<div class="modal-content">
+			<h2>Welcome to Chicken Society!</h2>
+			<p>You must agree to our <a href="/website/terms-of-service.html" target="_blank">Terms of Service</a> and
+				<a href="/website/privacy-policy.html" target="_blank">Privacy Policy</a> before using the site.
+			</p>
+			<label>
+				<input type="checkbox" id="agree-checkbox" />
+				I have read and agree to the Terms of Service and Privacy Policy
+			</label>
+			<br />
+			<button id="agree-button" class="disabled" disabled>Continue</button>
+		</div>
+	</div>
+
 	<div class="page-container">
 		<div class="content-container">
 			<!-- Canvas to render Game -->
@@ -63,11 +86,12 @@
 			<div id="footer">
 				<!-- Donation button -->
 				<script type='text/javascript' src='https://storage.ko-fi.com/cdn/widget/Widget_2.js'></script>
-				<script type='text/javascript'>kofiwidget2.init('Support us on Ko-fi', '#72a4f2', '');kofiwidget2.draw();</script> 
+				<script
+					type='text/javascript'>kofiwidget2.init('Support us on Ko-fi', '#72a4f2', ''); kofiwidget2.draw();</script>
 				<!-- Goodest Software Info -->
 				<p>2025 Goodest Software</p>
 				<a href="/website/terms-of-service.html" target="_blank">Terms of Service</a> |
-  				<a href="/website/privacy-policy.html" target="_blank">Privacy Policy</a>
+				<a href="/website/privacy-policy.html" target="_blank">Privacy Policy</a>
 			</div>
 		</div>
 	</div>
@@ -77,7 +101,7 @@
 		{"imports": {}}
 	</script>
 	<script src="game/login.js"></script>
-	
+
 	<!-- Socket.IO v4.7.2 with Msgpack parser -->
 	<!-- May need to be updated whenever server's socket.io version is updated. -->
 	<script src="socket.io.msgpack.min.js"></script>
@@ -92,6 +116,35 @@
 
 	<!-- Run game code -->
 	<script src="game/main.js" type="module"></script>
+
+	<!-- Terms of Service Modal & Privacy Policy Script -->
+	<script>
+		document.addEventListener("DOMContentLoaded", () => {
+			const modal = document.getElementById("tos-modal");
+			const checkbox = document.getElementById("agree-checkbox");
+			const button = document.getElementById("agree-button");
+
+			checkbox.addEventListener("change", () => {
+				if (checkbox.checked) {
+					button.disabled = false;
+					button.classList.remove("disabled");
+					button.classList.add("enabled");
+				} else {
+					button.disabled = true;
+					button.classList.remove("enabled");
+					button.classList.add("disabled");
+				}
+			});
+
+			button.addEventListener("click", () => {
+				if (!button.disabled) {
+					modal.style.display = "none";
+				}
+			});
+		});
+	</script>
+
+
 </body>
 
 </html>

--- a/website/index.html
+++ b/website/index.html
@@ -66,6 +66,8 @@
 				<script type='text/javascript'>kofiwidget2.init('Support us on Ko-fi', '#72a4f2', '');kofiwidget2.draw();</script> 
 				<!-- Goodest Software Info -->
 				<p>2025 Goodest Software</p>
+				<a href="/website/terms-of-service.html" target="_blank">Terms of Service</a> |
+  				<a href="/website/privacy-policy.html" target="_blank">Privacy Policy</a>
 			</div>
 		</div>
 	</div>

--- a/website/privacy-policy.html
+++ b/website/privacy-policy.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>Chicken Society</title>
+	<link rel="icon" type="image/x-icon" href="./assets/favicon.png">
+	<link rel="stylesheet" type="text/css" href="styles.css">
+</head>
+
+<!-- Navigation Bar -->
+<nav>
+	<ul id="navigation-bar-list">
+		<!-- Chicken Society logo -->
+		<li id="home-link">
+			<div id="home">
+				<a href="#"><img src="./assets/logo.png" id="logo"></a>
+			</div>
+		</li>
+		<!-- Sign In and Register dropdowns -->
+		<div id="dropdowns">
+			<li class="dropdown">
+				<button class="dropdown-button">Sign In</button>
+				<div class="dropdown-content">
+					<div class="loginContainer">
+						<form id="loginForm">
+							<input id="username-field" class="login-stuff" type="text" placeholder="Username"
+								name="username" maxlength="16" autocomplete="off" required />
+							<input id="password-field" class="login-stuff" type="password" placeholder="Password"
+								name="password" maxlength="16" autocomplete="off" required />
+							<button id="login-button" class="login-stuff" type="button">Login</button>
+						</form>
+					</div>
+				</div>
+			</li>
+			<li class="dropdown">
+				<button class="dropdown-button">Register</button>
+				<div class="dropdown-content">
+					<div class="loginContainer">
+						<form id="registerForm">
+							<input id="register-username-field" class="register-stuff" type="text"
+								placeholder="Username" name="registerUsername" maxlength="16" autocomplete="off"
+								required />
+							<input id="register-password-field" class="register-stuff" type="password"
+								placeholder="Password" name="registerPassword" maxlength="16" autocomplete="off"
+								required />
+							<input id="register-email-field" class="register-stuff" type="email" placeholder="Email"
+								name="registerEmail" maxlength="32" autocomplete="off" required />
+							<button id="register-button" class="register-stuff" type="button">Register</button>
+						</form>
+					</div>
+				</div>
+			</li>
+		</div>
+	</ul>
+</nav>
+
+<body>
+	<div class="page-container">
+		<div class="content-container">
+			<h1>Privacy Policy (placeholder)</h1>
+			<p>Welcome to Chicken Society! This Privacy Policy explains how we collect, use, and protect your
+				information when you use our game. By using Chicken Society, you agree to the collection and use of
+				information in accordance with this policy.</p>
+		</div>
+	</div>
+
+</body>
+
+</html>

--- a/website/styles.css
+++ b/website/styles.css
@@ -6,7 +6,7 @@ body{
 	padding: 0;
 	width: 100%;
 	height: 100%;
-	overflow: hidden;
+	overflow: auto;
 }
 
 .page-container{

--- a/website/styles.css
+++ b/website/styles.css
@@ -1,3 +1,13 @@
+/* Load fonts */
+@font-face {
+	/* Game fonts (need to be loaded here to be used in Chicken Society) */
+	font-family: 'Pixel';
+	src: url('assets/fonts/publicpixel.ttf') format('truetype');
+	/* You can include additional font formats here for better browser compatibility */
+}
+
+@import url('https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap');
+
 /* Page content */
 body{
 	/* Background */
@@ -7,6 +17,7 @@ body{
 	width: 100%;
 	height: 100%;
 	overflow: auto;
+    font-family: 'Inter', sans-serif; /* Use a pixel font for the entire page */
 }
 
 .page-container{
@@ -189,6 +200,7 @@ form {
 	background-color: rgb(251, 236, 211);
 	border: 1px solid #e5e5e500;
 	transition: all 0.3s cubic-bezier(0.15, 0.83, 0.66, 1);
+    font-family: 'Inter', sans-serif; 
 } 
 
 #login-button, #register-button {
@@ -225,10 +237,71 @@ form {
 
 }
 
-/* Load fonts */
-@font-face {
-	/* Game fonts (need to be loaded here to be used in Chicken Society) */
-	font-family: 'Pixel';
-	src: url('assets/fonts/publicpixel.ttf') format('truetype');
-	/* You can include additional font formats here for better browser compatibility */
+#footer a {
+    color: #806649;
 }
+
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+}
+
+.modal-content {
+  background: #fffcf0;
+  padding: 2rem;
+  border-radius: 10px;
+  max-width: 400px;
+  text-align: center;
+}
+
+.modal-content h2 {
+  margin: 0;
+  font-size: 1.5rem;
+    color: #ec9027;
+}
+
+.modal-content a {
+  color: #1e3a8a;
+  text-decoration: underline;
+}
+
+.modal-content button {
+  background: #ec9027;
+  color: white;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 5px;
+  cursor: pointer;
+  margin-top: 0.75rem;
+  transition: background-color 0.3s ease-in-out;
+}
+
+/* Style when disabled */
+.modal-content button.disabled {
+  background-color: #a0a0a0;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+/* Style when enabled (normal active state) */
+.modal-content button.enabled {
+  background: #1e40af;
+  color: white;
+  cursor: pointer;
+  transition: 0.3s ease-in-out;
+
+}
+
+.modal-content button.enabled:hover {
+  background: #ec9027;
+}
+
+

--- a/website/terms-of-service.html
+++ b/website/terms-of-service.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Chicken Society</title>
+    <link rel="icon" type="image/x-icon" href="./assets/favicon.png">
+    <link rel="stylesheet" type="text/css" href="styles.css">
+</head>
+
+<!-- Navigation Bar -->
+<nav>
+    <ul id="navigation-bar-list">
+        <!-- Chicken Society logo -->
+        <li id="home-link">
+            <div id="home">
+                <a href="#"><img src="./assets/logo.png" id="logo"></a>
+            </div>
+        </li>
+        <!-- Sign In and Register dropdowns -->
+        <div id="dropdowns">
+            <li class="dropdown">
+                <button class="dropdown-button">Sign In</button>
+                <div class="dropdown-content">
+                    <div class="loginContainer">
+                        <form id="loginForm">
+                            <input id="username-field" class="login-stuff" type="text" placeholder="Username"
+                                name="username" maxlength="16" autocomplete="off" required />
+                            <input id="password-field" class="login-stuff" type="password" placeholder="Password"
+                                name="password" maxlength="16" autocomplete="off" required />
+                            <button id="login-button" class="login-stuff" type="button">Login</button>
+                        </form>
+                    </div>
+                </div>
+            </li>
+            <li class="dropdown">
+                <button class="dropdown-button">Register</button>
+                <div class="dropdown-content">
+                    <div class="loginContainer">
+                        <form id="registerForm">
+                            <input id="register-username-field" class="register-stuff" type="text"
+                                placeholder="Username" name="registerUsername" maxlength="16" autocomplete="off"
+                                required />
+                            <input id="register-password-field" class="register-stuff" type="password"
+                                placeholder="Password" name="registerPassword" maxlength="16" autocomplete="off"
+                                required />
+                            <input id="register-email-field" class="register-stuff" type="email" placeholder="Email"
+                                name="registerEmail" maxlength="32" autocomplete="off" required />
+                            <button id="register-button" class="register-stuff" type="button">Register</button>
+                        </form>
+                    </div>
+                </div>
+            </li>
+        </div>
+    </ul>
+</nav>
+
+<body>
+    <div class="page-container">
+        <div class="content-container">
+            <h1>Terms of Service (placeholder)</h1>
+            <p>Welcome to Chicken Society! By accessing or using our game, you agree to comply with the following terms
+                and conditions. If you do not agree with any part of these terms, you must not use our game.</p>
+        </div>
+    </div>
+
+</body>
+
+</html>


### PR DESCRIPTION
**Description:**
This PR adds a modal popup requiring users to agree to the Terms of Service and Privacy Policy before using the site. The modal includes:

- A full-screen dark overlay that prevents interaction with the site
- A modal box with links to Terms of Service and Privacy Policy
- A checkbox users must check before continuing
- A "Continue" button that remains disabled (gray) until the box is checked
- The modal is styled and blocks access until the agreement is acknowledged.

Also added links to the footer for the same agreements.
<img width="200" alt="Screenshot 2025-06-19 at 7 59 31 PM" src="https://github.com/user-attachments/assets/b6ac93e1-c993-422d-bec1-69f116f661b5" />

**Notes:**
Can optionally add localStorage later to remember user agreement across sessions.

**Files updated:**
- index.html
- styles.css
- Inline modal logic in <script> tag

**Files added:**
- privacy_policy.html
- terms_of_service.html

---

**Video of changes:**

https://github.com/user-attachments/assets/656644cc-6012-4988-b667-75d4c815f92b


